### PR TITLE
docs: add simplified UI guide and simplify API guide for custom role

### DIFF
--- a/docs/custom_role/guide-simplified.mdx
+++ b/docs/custom_role/guide-simplified.mdx
@@ -1,0 +1,85 @@
+---
+title: Creating a Certificate Administrator Custom Role via the F5 XC Console
+---
+
+This guide walks through creating a custom RBAC role using the F5 Distributed
+Cloud Console UI. The role grants full CRUD access to SSL/TLS certificates and
+certificate chains. For the programmatic (API) approach, see the
+[API guide](./guide).
+
+## Prerequisites
+
+- Admin access to the F5 Distributed Cloud Console
+
+## Step 1: Navigate to Role Management
+
+1. Log in to the F5 Distributed Cloud Console
+2. Click the **Administration** tile on the home page
+3. In the left navigation menu, select **IAM** &gt; **Roles**
+4. Click **+ Add Role**
+
+## Step 2: Name the Role
+
+Enter `cert-admin` in the **Role Name** field.
+
+Role naming rules:
+
+- Lowercase letters, numbers, and hyphens only
+- Must start with two lowercase letters
+- Maximum 64 characters
+
+## Step 3: Add Certificate API Groups
+
+1. Click **+ Allowed API Groups**
+2. In the search/filter field, type `certificate`
+3. Select all 10 API groups listed below:
+
+| API Group | Permission |
+| --------- | ---------- |
+| `ves-io-schema-certificate-api-create-0` | Create certificates |
+| `ves-io-schema-certificate-api-get-0` | View a certificate |
+| `ves-io-schema-certificate-api-list-0` | List certificates |
+| `ves-io-schema-certificate-api-replace-0` | Update certificates |
+| `ves-io-schema-certificate-api-delete-0` | Delete certificates |
+| `ves-io-schema-certificate_chain-api-create-0` | Create certificate chains |
+| `ves-io-schema-certificate_chain-api-get-0` | View a certificate chain |
+| `ves-io-schema-certificate_chain-api-list-0` | List certificate chains |
+| `ves-io-schema-certificate_chain-api-replace-0` | Update certificate chains |
+| `ves-io-schema-certificate_chain-api-delete-0` | Delete certificate chains |
+
+4. Click **Save** to confirm the selected API groups
+
+## Step 4: Save the Role
+
+Review the selected API groups in the summary, then click **Save** to create
+the role.
+
+## Step 5: Verify the Role
+
+1. Navigate to **IAM** &gt; **Roles**
+2. Click **cert-admin** in the role list
+3. Confirm all 10 API groups are listed
+4. Click the **Elements** count to inspect the underlying API paths each group
+   grants access to
+
+## Understanding the Permission Model
+
+API groups are **system-defined** — you do not create them. F5 XC
+pre-creates an API group for every resource and operation following the naming
+convention:
+
+```
+ves-io-schema-\{resource\}-api-\{operation\}-0
+```
+
+Where `{operation}` is one of: `create`, `get`, `list`, `replace`, `delete`.
+
+A custom role is a named collection of these API groups. By selecting the 10
+certificate-related groups, the `cert-admin` role grants full SSL/TLS
+management without exposing any other platform capabilities.
+
+## References
+
+- [Manage Roles — F5 XC Docs](https://docs.cloud.f5.com/docs/how-to/user-mgmt/roles)
+- [RBAC Concepts — F5 XC Docs](https://docs.cloud.f5.com/docs-v2/platform/concepts/rbac)
+- [Programmatic Guide (API)](./guide)

--- a/docs/custom_role/guide.mdx
+++ b/docs/custom_role/guide.mdx
@@ -1,0 +1,249 @@
+---
+title: Creating a Certificate Administrator Custom Role via the F5 XC API
+---
+
+This guide walks through creating a custom RBAC role in F5 Distributed Cloud
+that grants full CRUD permission on SSL/TLS certificates and certificate
+chains. For a UI-based approach, see the
+[simplified console guide](./guide-simplified).
+
+## How F5 XC RBAC Works
+
+F5 XC uses a three-tier permission model:
+
+```
+api_group_element  (read-only, system-defined)
+       │
+       ▼
+   api_group       (read-only, system-defined)
+       │
+       ▼
+     role           (full CRUD — this is what you create)
+```
+
+1. **`api_group_element`** — Defines a regex path and HTTP methods
+   (e.g., `POST /api/config/.*/certificates`). System-managed; you cannot
+   create, modify, or delete these.
+
+2. **`api_group`** — A named collection of `api_group_element` references.
+   System-managed; you cannot create, modify, or delete these. Named using the
+   convention `ves-io-schema-{resource}-api-{operation}-0`.
+
+3. **`role`** — References `api_group` names in an array. **This is the only
+   tier you create.** Use the custom role endpoints to attach specific
+   `api_groups` to a role.
+
+## Prerequisites
+
+- An F5 XC API token with admin privileges
+- `curl` and `jq` installed
+
+Set your environment variables:
+
+```bash
+export F5XC_TENANT="your-tenant"
+export F5XC_API_URL="https://${F5XC_TENANT}.console.ves.volterra.io"
+export F5XC_API_TOKEN="your-api-token"
+export F5XC_NAMESPACE="shared"
+```
+
+## Step 1: Discover Certificate API Groups
+
+List all system-defined `api_group` objects and filter for certificate-related
+entries:
+
+```bash
+curl -s \
+  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+  "${F5XC_API_URL}/api/web/namespaces/${F5XC_NAMESPACE}/api_groups" \
+  | jq '[.items[] | select(.name | test("certificate")) | .name]'
+```
+
+Expected output (names may vary by tenant version):
+
+```json
+[
+  "ves-io-schema-certificate-api-create-0",
+  "ves-io-schema-certificate-api-delete-0",
+  "ves-io-schema-certificate-api-get-0",
+  "ves-io-schema-certificate-api-list-0",
+  "ves-io-schema-certificate-api-replace-0",
+  "ves-io-schema-certificate_chain-api-create-0",
+  "ves-io-schema-certificate_chain-api-delete-0",
+  "ves-io-schema-certificate_chain-api-get-0",
+  "ves-io-schema-certificate_chain-api-list-0",
+  "ves-io-schema-certificate_chain-api-replace-0"
+]
+```
+
+To see what a specific `api_group` contains:
+
+```bash
+curl -s \
+  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+  "${F5XC_API_URL}/api/web/namespaces/${F5XC_NAMESPACE}/api_groups/ves-io-schema-certificate-api-create-0" \
+  | jq .
+```
+
+## Step 2: Create the Custom Role
+
+Use the custom role creation endpoint. The `api_groups` array references the
+system-defined api_group names discovered in Step 1.
+
+Create the custom role with full CRUD access to both certificates and
+certificate chains:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  "${F5XC_API_URL}/api/web/custom/namespaces/${F5XC_NAMESPACE}/roles" \
+  -d '{
+    "metadata": {
+      "name": "cert-admin",
+      "namespace": "'"${F5XC_NAMESPACE}"'"
+    },
+    "spec": {},
+    "api_groups": [
+      "ves-io-schema-certificate-api-create-0",
+      "ves-io-schema-certificate-api-get-0",
+      "ves-io-schema-certificate-api-list-0",
+      "ves-io-schema-certificate-api-replace-0",
+      "ves-io-schema-certificate-api-delete-0",
+      "ves-io-schema-certificate_chain-api-create-0",
+      "ves-io-schema-certificate_chain-api-get-0",
+      "ves-io-schema-certificate_chain-api-list-0",
+      "ves-io-schema-certificate_chain-api-replace-0",
+      "ves-io-schema-certificate_chain-api-delete-0"
+    ]
+  }'
+```
+
+## Step 3: Verify the Role
+
+Retrieve the role using the custom GET endpoint to confirm the `api_groups`
+are attached:
+
+```bash
+curl -s \
+  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+  "${F5XC_API_URL}/api/web/custom/namespaces/${F5XC_NAMESPACE}/roles/cert-admin" \
+  | jq '{name: .object.metadata.name, api_groups: .api_groups}'
+```
+
+Expected output:
+
+```json
+{
+  "name": "cert-admin",
+  "api_groups": [
+    "ves-io-schema-certificate-api-create-0",
+    "ves-io-schema-certificate-api-get-0",
+    "ves-io-schema-certificate-api-list-0",
+    "ves-io-schema-certificate-api-replace-0",
+    "ves-io-schema-certificate-api-delete-0",
+    "ves-io-schema-certificate_chain-api-create-0",
+    "ves-io-schema-certificate_chain-api-get-0",
+    "ves-io-schema-certificate_chain-api-list-0",
+    "ves-io-schema-certificate_chain-api-replace-0",
+    "ves-io-schema-certificate_chain-api-delete-0"
+  ]
+}
+```
+
+## Step 4: Update the Role (Optional)
+
+To add or remove `api_groups` from an existing role, use the custom PUT
+endpoint:
+
+```bash
+curl -s -X PUT \
+  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  "${F5XC_API_URL}/api/web/custom/namespaces/${F5XC_NAMESPACE}/roles/cert-admin" \
+  -d '{
+    "name": "cert-admin",
+    "namespace": "'"${F5XC_NAMESPACE}"'",
+    "spec": {},
+    "api_groups": [
+      "ves-io-schema-certificate-api-get-0",
+      "ves-io-schema-certificate-api-list-0",
+      "ves-io-schema-certificate_chain-api-get-0",
+      "ves-io-schema-certificate_chain-api-list-0"
+    ]
+  }'
+```
+
+This example downgrades the role to read-only access (get and list only) for
+both certificates and certificate chains.
+
+## Step 5: Delete the Role (Optional)
+
+Delete uses the standard role endpoint:
+
+```bash
+curl -s -X DELETE \
+  -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+  "${F5XC_API_URL}/api/web/namespaces/${F5XC_NAMESPACE}/roles/cert-admin"
+```
+
+## API Reference
+
+All paths verified against the OpenAPI specs in this repository.
+
+### Role Endpoints (Custom — includes `api_groups`)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| POST | `/api/web/custom/namespaces/{namespace}/roles` | Create a custom role |
+| GET | `/api/web/custom/namespaces/{namespace}/roles` | List custom roles |
+| GET | `/api/web/custom/namespaces/{namespace}/roles/{name}` | Get a custom role |
+| PUT | `/api/web/custom/namespaces/{namespace}/roles/{name}` | Replace a custom role |
+
+### Role Endpoints (Standard)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| DELETE | `/api/web/namespaces/{namespace}/roles/{name}` | Delete a role |
+| GET | `/api/web/namespaces/{namespace}/roles/{name}` | Get a role |
+| GET | `/api/web/namespaces/{namespace}/roles` | List roles |
+
+### Discovery Endpoints (Read-Only)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| GET | `/api/web/namespaces/{namespace}/api_groups` | List all api_groups |
+| GET | `/api/web/namespaces/{namespace}/api_groups/{name}` | Get an api_group |
+| GET | `/api/web/namespaces/{namespace}/api_group_elements` | List all api_group_elements |
+| GET | `/api/web/namespaces/{namespace}/api_group_elements/{name}` | Get an api_group_element |
+
+### Certificate Endpoints (What the Role Grants Access To)
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| POST | `/api/config/namespaces/{namespace}/certificates` | Create a certificate |
+| GET | `/api/config/namespaces/{namespace}/certificates` | List certificates |
+| GET | `/api/config/namespaces/{namespace}/certificates/{name}` | Get a certificate |
+| PUT | `/api/config/namespaces/{namespace}/certificates/{name}` | Replace a certificate |
+| DELETE | `/api/config/namespaces/{namespace}/certificates/{name}` | Delete a certificate |
+| POST | `/api/config/namespaces/{namespace}/certificate_chains` | Create a certificate chain |
+| GET | `/api/config/namespaces/{namespace}/certificate_chains` | List certificate chains |
+| GET | `/api/config/namespaces/{namespace}/certificate_chains/{name}` | Get a certificate chain |
+| PUT | `/api/config/namespaces/{namespace}/certificate_chains/{name}` | Replace a certificate chain |
+| DELETE | `/api/config/namespaces/{namespace}/certificate_chains/{name}` | Delete a certificate chain |
+
+## Why `api_group` and `api_group_element` Are Read-Only
+
+These objects are **system-defined** by F5 XC. The platform pre-creates
+`api_group_element` entries for every API path and groups them into
+`api_group` objects following a consistent naming convention:
+
+```
+ves-io-schema-{resource}-api-{operation}-0
+```
+
+Where `{operation}` is one of: `create`, `get`, `list`, `replace`, `delete`.
+
+You do not need to create these — they already exist for every resource in the
+system. Your job is to **discover** the relevant group names (Step 1) and
+**reference** them in your custom role (Step 2).


### PR DESCRIPTION
## Summary

Add a new simplified UI guide for creating a Certificate Administrator custom role via the F5 XC Console, and simplify the existing API guide to a single option covering all 10 certificate API groups.

## Changes

### New file: `docs/custom_role/guide-simplified.md`
- Step-by-step instructions using the F5 XC Console UI
- Covers navigating to role management, naming the role, selecting all 10 certificate API groups, saving, and verifying
- Includes permission model explanation and external references
- Cross-links to the programmatic API guide

### Modified: `docs/custom_role/guide.md`
- Removed dual-option pattern (certificates-only vs certificates + chains)
- Single curl example now includes all 10 API groups (certificates and certificate chains)
- Updated Step 3 verification output to show all 10 API groups
- Updated Step 4 update example to show read-only downgrade for both resource types
- Added cross-link to the new simplified console guide
- Fixed markdownlint MD060 table separator formatting

## Testing

- [x] Both files pass `markdownlint-cli2` with zero errors
- [x] Cross-links between guides are correct
- [x] All 10 API groups consistently referenced across both guides

## Related

Closes #76