### PR TITLE
docs: rename cert-admin to example-cert-admin in custom role guides

### DIFF
--- a/docs/custom-role-api.mdx
+++ b/docs/custom-role-api.mdx
@@ -55,7 +55,7 @@ exposes GET endpoints for these. Roles can only reference existing `api_group`
 names, and there is no `api_group` scoped exclusively to certificates.
 
 **Mitigation — namespace isolation:** Create a dedicated namespace for
-certificate resources and assign the `cert-admin` role scoped to that
+certificate resources and assign the `example-cert-admin` role scoped to that
 namespace only. The user retains proxy-level permissions but cannot access
 resources in other namespaces, limiting the blast radius of the broader
 api_group scope.
@@ -132,7 +132,7 @@ curl -s -X POST \
   "${F5XC_API_URL}/api/web/custom/namespaces/system/roles" \
   -d '{
     "metadata": {
-      "name": "cert-admin",
+      "name": "example-cert-admin",
       "namespace": "system"
     },
     "spec": {},
@@ -151,7 +151,7 @@ are attached:
 ```bash
 curl -s \
   -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/web/custom/namespaces/system/roles/cert-admin" \
+  "${F5XC_API_URL}/api/web/custom/namespaces/system/roles/example-cert-admin" \
   | jq '{name: .object.metadata.name, api_groups: .api_groups}'
 ```
 
@@ -159,7 +159,7 @@ Expected output:
 
 ```json
 {
-  "name": "cert-admin",
+  "name": "example-cert-admin",
   "api_groups": [
     "ves-io-proxy-read",
     "ves-io-proxy-write"
@@ -176,9 +176,9 @@ endpoint:
 curl -s -X PUT \
   -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
   -H "Content-Type: application/json" \
-  "${F5XC_API_URL}/api/web/custom/namespaces/system/roles/cert-admin" \
+  "${F5XC_API_URL}/api/web/custom/namespaces/system/roles/example-cert-admin" \
   -d '{
-    "name": "cert-admin",
+    "name": "example-cert-admin",
     "namespace": "system",
     "spec": {},
     "api_groups": [
@@ -197,7 +197,7 @@ Delete uses the standard role endpoint:
 ```bash
 curl -s -X DELETE \
   -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-  "${F5XC_API_URL}/api/web/namespaces/system/roles/cert-admin"
+  "${F5XC_API_URL}/api/web/namespaces/system/roles/example-cert-admin"
 ```
 
 ## API Reference

--- a/docs/custom-role-ui.mdx
+++ b/docs/custom-role-ui.mdx
@@ -36,7 +36,7 @@ api_group_element  (read-only, system-defined)
    tier you create.** Use the custom role endpoints to attach specific
    `api_groups` to a role.
 
-By selecting the proxy read/write groups, the `cert-admin` role grants SSL/TLS
+By selecting the proxy read/write groups, the `example-cert-admin` role grants SSL/TLS
 certificate management as part of broader proxy resource access.
 
 ## Scope and Limitations
@@ -51,7 +51,7 @@ reference existing group names. No system-defined group is scoped exclusively
 to certificate operations.
 
 **Mitigation — namespace isolation:** Place certificate resources in a
-dedicated namespace and scope the `cert-admin` role to that namespace. This
+dedicated namespace and scope the `example-cert-admin` role to that namespace. This
 prevents the user from accessing proxy resources in other namespaces while
 still granting full certificate management within the isolated namespace.
 
@@ -68,7 +68,7 @@ still granting full certificate management within the isolated namespace.
 
 ## Step 2: Name the Role
 
-Enter `cert-admin` in the **Role Name** field.
+Enter `example-cert-admin` in the **Role Name** field.
 
 Role naming rules:
 
@@ -106,7 +106,7 @@ the role.
 ## Step 5: Verify the Role
 
 1. Navigate to **IAM** &gt; **Roles**
-2. Click **cert-admin** in the role list
+2. Click **example-cert-admin** in the role list
 3. Confirm both API groups are listed
 
 ## References


### PR DESCRIPTION
## Proposed Changes

Rename all occurrences of `cert-admin` to `example-cert-admin` in both custom role guides to clearly distinguish user-chosen example names from system-defined values.

## Files Changed

- `docs/custom-role-api.mdx` — 7 occurrences updated
- `docs/custom-role-ui.mdx` — 4 occurrences updated

## Linked Issues

Closes #90

## Checklist

- [x] Followed conventional commit format
- [x] All occurrences replaced consistently across both files
- [x] No system-defined names were modified
- [x] PR links to a GitHub issue