### PR TITLE
fix: add missing description frontmatter to custom-role docs

### DIFF
--- a/docs/custom-role-api.mdx
+++ b/docs/custom-role-api.mdx
@@ -1,5 +1,6 @@
 ---
 title: Certificate Admin Role - API
+description: "Create a custom role restricting users to SSL/TLS certificate management via API"
 sidebar:
   label: Custom Role - API
 ---

--- a/docs/custom-role-ui.mdx
+++ b/docs/custom-role-ui.mdx
@@ -1,5 +1,6 @@
 ---
 title: Certificate Admin Role - UI
+description: "Create a custom role restricting users to SSL/TLS certificate management via the F5 XC console UI"
 sidebar:
   label: Custom Role - UI
 ---


### PR DESCRIPTION
Add `description:` frontmatter to 2 .mdx files that were missing it, so llms.txt sections show descriptions.

- `docs/custom-role-api.mdx`
- `docs/custom-role-ui.mdx`

Refs f5xc-salesdemos/xcsh#223