### PR TITLE
docs: add frontmatter description and llms-config for llms.txt hierarchy

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Administration
+description: Tenant management, RBAC, and platform settings for F5 Distributed Cloud.
 hero:
   tagline: Tenant management, RBAC, and platform settings.
   image:

--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,0 +1,11 @@
+{
+  "customSets": [
+    {
+      "label": "Custom Roles",
+      "description": "Creating custom RBAC roles via API and console UI",
+      "paths": ["custom-role*"]
+    }
+  ],
+  "promote": ["index*"],
+  "demote": []
+}


### PR DESCRIPTION
## Summary

- Add `description` frontmatter field to `docs/index.mdx` for llms.txt metadata generation
- Add `docs/llms-config.json` configuration file for the llms.txt hierarchy plugin

Closes #268

Refs f5xc-salesdemos/xcsh#223

## Test plan

- [ ] CI checks pass
- [ ] Verify `docs/llms-config.json` is valid JSON and Biome-formatted
- [ ] Verify `docs/index.mdx` frontmatter contains the new `description` field