### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.claude/governance.json
+++ b/.claude/governance.json
@@ -10,6 +10,7 @@
       ".mypy.ini",
       ".github/workflows/super-linter.yml"
     ],
+    "terraform-provider-xcsh": [".github/workflows/translation-audit.yml", "scripts/locale-lint.sh"],
     "api-specs": [".ruff.toml", ".python-lint", ".mypy.ini"],
     "api-specs-enriched": [".ruff.toml", ".python-lint", ".mypy.ini"],
     "vscode-xcsh": [".ruff.toml", ".python-lint", ".mypy.ini", ".isort.cfg"],


### PR DESCRIPTION
Closes #536

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .claude/governance.json