### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,5 @@
 {
-  "MD013": false,
+  "MD013": { "line_length": 400 },
   "MD029": false,
   "MD033": false,
   "MD040": false,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Apply where applicable to this repo:
 - **Root-cause only** — fix problems (including lint and CI failures) at the source; never skip, suppress, inline-disable, or hand-wave them. CI rejects masked issues.
 - **No backward compat** — prerelease code; make clean-break changes, no shims or deprecated interfaces.
 - **DRY** — reuse existing code, patterns, and content before adding new.
-- **Clean branches** — a branch is for trial-and-error; only verified, feature-complete code merges. A PR means "this works", not "does this work?" — never open or merge exploratory code, and drop unneeded (YAGNI) work. Once your PR is verified-merged, prune and delete your merged local branch so the workstation does not accumulate branches (see CONTRIBUTING.md for safe `[gone]` cleanup).
+- **Clean branches** — only verified, feature-complete code merges; never merge exploratory or unneeded (YAGNI) work. Cleanup is part of "done": once verified-merged, return to main, delete your merged branch, and report git hygiene (branch, uncommitted changes, stale `[gone]` branches) unprompted — see CONTRIBUTING.md for safe `[gone]` cleanup.
 - **Local vs CI** — `pre-commit` runs a subset; the `Lint Code Base` gate also runs textlint prose/terminology. Reproduce it before pushing.
 
 See `CONTRIBUTING.md` for the full detail.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,6 +149,11 @@ apply what fits.
 - When a change publishes a new version or artifact, close the loop end-to-end: download,
   install, and exercise the published version to confirm the fix is real — not merely
   that the pipeline reported success.
+- Leaving a clean workspace is part of "done": once merge is confirmed and CI is green,
+  return to `main`, delete your merged local branch, and proactively report git hygiene
+  — current branch, uncommitted or unmerged changes, and any stale `[gone]` branches —
+  rather than waiting to be asked. See "After merge: clean up local branches" for the
+  safe confirm-then-delete steps.
 
 ### No papering over problems
 


### PR DESCRIPTION
Closes #564

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- CONTRIBUTING.md
- CLAUDE.md
- .markdownlint.json