### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -42,7 +42,20 @@ jobs:
     # trusted-write-access + the reusable's fork guard; full closure requires a
     # dedicated bot/App identity for the automation or a branch-creation ruleset
     # restricting who may push those prefixes.
+    #
+    # SUSPENDED: gated on the `REVIEWER_ENABLED` org variable, which is currently
+    # unset, so this job never runs and nothing dispatches to the self-hosted
+    # runner. The reviewer could not reliably reach model inference or the VPN, so
+    # the check frequently never went green while it was a required context — a
+    # merge backlog caused by infrastructure rather than by code quality. The
+    # `review / claude-review` context was removed from branch protection first
+    # (docs-control#833); skipping this job while it was still required would have
+    # deadlocked every open PR. To restore, see "Restoring the reviewer" in
+    # REVIEWER-SPEC.md — set the variable BEFORE re-adding the required context.
+    # `vars` is used rather than `env` because the `env` context is not available
+    # in a job-level `if:`. An unset variable evaluates false, so this fails safe.
     if: >-
+      vars.REVIEWER_ENABLED == 'true' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       !(startsWith(github.head_ref, 'governance/') ||
         startsWith(github.head_ref, 'sync/') ||
@@ -68,8 +81,14 @@ jobs:
   # never post and the PR would deadlock. Post it as a passing commit status on
   # exactly those branches (same-repo only, so GITHUB_TOKEN can write and forks
   # are excluded). Condition MUST mirror the negated `review` condition above.
+  # Also gated on REVIEWER_ENABLED. While the reviewer is suspended the
+  # `review / claude-review` context is not required by any repo, so nothing needs
+  # this status — and posting a passing one would imply a review had happened when
+  # none did. Both jobs share the gate so the pair stays consistent: whichever way
+  # the variable is set, either both run or neither does.
   review-status-automated:
     if: >-
+      vars.REVIEWER_ENABLED == 'true' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       (startsWith(github.head_ref, 'governance/') ||
        startsWith(github.head_ref, 'sync/') ||

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ A hook blocks direct edits — open an issue in docs-control instead.
 - **Never sync by overwriting the working tree.** `git checkout <ref> -- .`, `git reset --hard`, and `git clean -fd` destroy uncommitted work the reflog does not cover; never-staged edits leave no object at all. Behind with work in progress? Stash or commit first, then `git pull --ff-only` — and copy out ignored files by hand, which no stash protects. See CONTRIBUTING.md.
 - `main` is protected — never commit or push to it directly.
 - Work on a feature branch and open a pull request.
-- Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check, and — on ecosystem repos — a Claude Code review) → auto-merge when every check is green → remote branch auto-deleted.
+- Lifecycle: linked issue → branch → PR → required CI (Lint Code Base, linked-issue check, translation-freshness audit) → auto-merge when every check is green → remote branch auto-deleted. The Claude Code review is **suspended** and is no longer part of this gate — see "CI (suspended)" below.
 
 ## Two review layers — never substitute one for the other
 
@@ -28,7 +28,7 @@ Reviewing a **spec or plan** and reviewing a **pull-request diff** are different
 | Layer | What it reviews | When | Tool | Authority |
 | ----- | --------------- | ---- | ---- | --------- |
 | **Local, pre-PR** | A spec, an implementation plan, or your own unpushed branch | Before a human reviews the document; before a push that opens or updates a PR; after each round of fixes | `codex:verified-code-review` | Advisory. Never a merge gate. |
-| **CI** | The pull-request diff | Automatically, on every PR | Self-hosted `review / claude-review` workflow | **Required and merge-gating.** |
+| **CI** | The pull-request diff | — | Self-hosted `review / claude-review` workflow | **Currently suspended.** Not running, not required. |
 
 ### Local, pre-PR (Codex second opinion)
 
@@ -48,9 +48,20 @@ Treat every second-opinion finding as external review feedback under `superpower
 
 Report the findings you dismissed and the evidence that dismissed them — a review that produced two refuted findings is not the same result as a review that produced none.
 
-### CI (the merge gate)
+### CI (suspended)
 
-The Claude Code review is a **required, merge-gating check** that can block. On a block, read its findings, fix at the source, and push to re-trigger it — never merge around it, disable it, or rename the branch to a bypass prefix. The local layer never replaces it. See CONTRIBUTING.md.
+**The Claude Code review is currently suspended and is no longer a required check.** The self-hosted reviewer could not reliably reach model inference or the VPN, so the check often never went green and blocked PRs for infrastructure reasons rather than code-quality ones.
+
+The `review / claude-review` context was removed from branch protection (docs-control#833), and the workflow is gated off behind the `REVIEWER_ENABLED` variable (docs-control#838).
+
+What this means for you now:
+
+- **Do not wait for it, and do not treat its absence as a problem.** No CI job reviews PR diffs at present.
+- Required checks are the linked-issue check, `Lint Code Base`, and `audit / Translation freshness` (plus any repo-specific contexts).
+- The local pre-PR layer above is now the only review step in practice. It remains **advisory** — it is not a gate and does not become one because the CI layer is absent.
+- **Do not re-enable it, re-add the required context, or work around the suspension** without going through REVIEWER-SPEC.md. Order matters: set the variable first and confirm a real review completes, then re-add the context. Reversing that deadlocks every open PR.
+
+When it is restored it becomes a required, merge-gating check again: on a block, read its findings, fix at the source, and push to re-trigger it — never merge around it or rename the branch to a bypass prefix. See CONTRIBUTING.md.
 
 ## Worktrees
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,11 @@ improving how customers are defended.
 Every change follows this path:
 
 ```
-Issue → Branch → PR (linked to issue) → CI + automated code review pass → auto-merge when green → Branch auto-deleted
+Issue → Branch → PR (linked to issue) → CI passes → auto-merge when green → Branch auto-deleted
 ```
+
+The automated code review used to sit in that chain. It is **currently suspended** — see
+[CI review](#ci-review-suspended).
 
 No exceptions. PRs without a linked issue will be blocked by CI.
 
@@ -171,8 +174,8 @@ If a branch falls behind `main` while its PR is open, use the **Update branch** 
 ## Step 5: Review and Merge
 
 - All required CI checks must pass before merge.
-- On ecosystem repos, an automated Claude Code review is a required check (see
-  [Automated code review](#automated-code-review)); address any blocking findings before merge.
+- The automated Claude Code review is **currently suspended** and is not a required check (see
+  [CI review](#ci-review-suspended)).
 - Merging is automated: once every required check is green, auto-merge squash-merges the PR.
 - The branch is automatically deleted after merge (`delete_branch_on_merge` is enabled); clean up
   your local branch afterward.
@@ -184,9 +187,20 @@ Review happens in two layers. They are not interchangeable, and neither substitu
 | Layer | What it reviews | Authority |
 | ----- | --------------- | --------- |
 | **Local, pre-PR** | A spec, an implementation plan, or an unpushed branch | Advisory |
-| **CI** | The pull-request diff | **Required and merge-gating** |
+| **CI** | The pull-request diff | **Currently suspended** — not running, not required |
 
-### CI review (the gate)
+### CI review (suspended)
+
+> **Suspended.** The self-hosted reviewer could not reliably reach model inference or the VPN, so
+> the check often never went green and blocked pull requests for infrastructure reasons rather than
+> code-quality ones. The `review / claude-review` context has been removed from branch protection
+> (docs-control#833) and the workflow is gated off behind the `REVIEWER_ENABLED` variable
+> (docs-control#838). **No CI job currently reviews pull-request diffs.** Do not wait for it, and do
+> not treat its absence as a fault. Restoring it is described in `REVIEWER-SPEC.md` — set the
+> variable and confirm a real review completes *before* re-adding the required context, because the
+> reverse order deadlocks every open pull request.
+
+The rest of this section describes the reviewer as it behaves when enabled.
 
 Every downstream pull request is reviewed by a **Claude Code reviewer** running on a self-hosted
 runner. It is a **required status check** (`review / claude-review`) — auto-merge will not merge
@@ -235,7 +249,7 @@ The `main` branch is protected. The following rules are enforced:
 
 - No direct pushes to `main` — all changes go through PRs
 - No force pushes
-- Required status checks: `Check linked issues` and `Lint Code Base` must pass; ecosystem repos additionally require the `review / claude-review` check
+- Required status checks: `Check linked issues`, `Lint Code Base` and `audit / Translation freshness` must pass, plus any repo-specific contexts. The `review / claude-review` check is **suspended** and no longer required
 - Admin enforcement enabled — these rules apply to everyone
 
 ## AI Assistant Guidelines


### PR DESCRIPTION
Closes #626

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- CONTRIBUTING.md
- CLAUDE.md
- .github/workflows/code-review.yml