### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,6 +106,24 @@ repos:
         types: [markdown]
 
   # ===========================================================================
+  # Shell formatting — pinned to Super-Linter's SHELL_SHFMT v3.13.1.
+  # The local Python hook installs the mirror's checksum-verified binary without
+  # requiring a global shfmt. Keeping the dependency under repo: local prevents
+  # pre-commit.ci's weekly autoupdater from advancing it ahead of Super-Linter.
+  # ===========================================================================
+  - repo: local
+    hooks:
+      - id: shfmt
+        name: Shell format
+        entry: shfmt
+        language: python
+        additional_dependencies:
+          - git+https://github.com/scop/pre-commit-shfmt@05c1426671b9237fb5e1444dd63aa5731bec0dfb # v3.13.1-1
+        args: ["--write", "--indent", "2"]
+        types: [shell]
+        exclude_types: [csh, tcsh]
+
+  # ===========================================================================
   # Shell script analysis — config: .shellcheckrc (SC2016 disabled there)
   # Replaces: shellcheck in super-linter
   # (was passing SHELLCHECK_OPTS="-e SC2016")


### PR DESCRIPTION
Closes #654

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .pre-commit-config.yaml